### PR TITLE
:bug: fix: import on list

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
+cdktf-cdktf-provider-google==8.0.8
 GitPython==3.1.32
+google-auth==2.22.0
 importlib-metadata==6.8.0
 importlib-resources==6.0.0
 thipster==0.23.6

--- a/thipstercli/helpers.py
+++ b/thipstercli/helpers.py
@@ -1,6 +1,7 @@
 """Functions to get thipster classes and modules."""
 import importlib
 import os
+import pkgutil
 from pathlib import Path
 
 
@@ -74,11 +75,11 @@ def get_thipster_module_class_list(module_name: str) -> list[str]:
     list[str]
         The list of classes contained in the module.
     """
-    module = importlib.import_module(
+    package = pkgutil.get_loader(
         f'thipster.{module_name.lower()}',
     )
     module_class_list = []
-    with os.scandir(Path(module.__file__).parent) as entries:
+    with os.scandir(Path(package.get_filename()).parent) as entries:
         for entry in entries:
             if entry.is_file() and entry.name.endswith('.py') and not \
                     entry.name.startswith('__'):


### PR DESCRIPTION
# Description

Google was not imported by default 
removed the import when running `providers list` command as it was importing the modules, causing an error (since google wasn't imported)
=> Also better perf

Fixes #82 

## Type of change

:bug: Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Ran tests 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
